### PR TITLE
fix join example

### DIFF
--- a/notebooks/Part_1_Spark_Datasets_and_Structured_Streaming.ipynb
+++ b/notebooks/Part_1_Spark_Datasets_and_Structured_Streaming.ipynb
@@ -222,7 +222,7 @@
     "val transactions = (spark.read\n",
     "    .option(\"inferSchema\", \"true\")\n",
     "    .option(\"header\", \"true\")\n",
-    "    .csv(\"data/transactions.csv\")\n",
+    "    .csv(\"data/transactions/*.csv\")\n",
     "    .as[Transaction])\n",
     "\n",
     "(users.join(transactions, users.col(\"id\") === transactions.col(\"userid\"))\n",


### PR DESCRIPTION
transactions are a partitioned csv file
could use simply `"data/transformations/"` or proposed `"data/transformations/*.csv"` in case users want to do this locally.